### PR TITLE
Kotlin codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
         - cd leetCodeSolutionsKotlin
         - ./gradlew build
       after_success:
-        - bash <(curl -s https://codecov.io/bash) -R ./src/main/kotlin
+        - bash <(curl -s https://codecov.io/bash) -R ./src/
     - language: python
       python:
         - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,14 @@ matrix:
         - ./bin/solutions -test
         - ./bin/unit_tests
       after_success:
-        - bash <(curl -s https://codecov.io/bash) -R .
+        - bash <(curl -s https://codecov.io/bash) -R ../
         - make clean
     - language: java
       script:
         - cd leetCodeSolutionsKotlin
         - ./gradlew build
       after_success:
-        - bash <(curl -s https://codecov.io/bash) -R .
+        - bash <(curl -s https://codecov.io/bash) -R ./src/main/kotlin
     - language: python
       python:
         - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,6 @@ env:
     - CODECOV_TOKEN="bf2b7da2-833f-47d6-8660-d149faed8097"
 after_success:
   # Run bash script to upload code coverage files
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash) -R src/leetCodeSolutions/
   - make clean
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,15 @@ matrix:
         - make
         - ./bin/solutions -test
         - ./bin/unit_tests
+      after_success:
+        - bash <(curl -s https://codecov.io/bash) -R .
+        - make clean
     - language: java
       script:
         - cd leetCodeSolutionsKotlin
         - ./gradlew build
+      after_success:
+        - bash <(curl -s https://codecov.io/bash) -R .
     - language: python
       python:
         - "3.5"
@@ -35,6 +40,8 @@ matrix:
       script:
         - cd leetCodeSolutionsPython
         - python -m pytest --cov-report term --cov .
+      after_success:
+        - bash <(curl -s https://codecov.io/bash) -R .
 
 before_install:
   - chmod +x ./leetCodeSolutionsKotlin/gradlew
@@ -44,8 +51,4 @@ env:
     # Token provided in settings of codecov
     # - CODECOV_TOKEN=:bf2b7da2-833f-47d6-8660-d149faed8097
     - CODECOV_TOKEN="bf2b7da2-833f-47d6-8660-d149faed8097"
-after_success:
-  # Run bash script to upload code coverage files
-  - bash <(curl -s https://codecov.io/bash) -R src/leetCodeSolutions/
-  - make clean
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
         - cd leetCodeSolutionsKotlin
         - ./gradlew build
       after_success:
-        - bash <(curl -s https://codecov.io/bash) -R ./src/
+        - bash <(curl -s https://codecov.io/bash) -R ./src/main/kotlin
     - language: python
       python:
         - "3.5"


### PR DESCRIPTION
Corrected code coverage on all builds:

- uploading each codecoverage report at the after_success of each of the builds, specifying the root folder:
  - For the C++, the repo root was chosen;
  - For the Python, the leetCodeSolutionsPython folder was chosen;
  - For the Kotlin, the source files folder had to be chosen in order fot the coverage to work properly.